### PR TITLE
chore: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Phylum, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,28 +13,34 @@ community. Unless otherwise specified, these common guidelines should be applied
 to all Rust code.
 
 Notable examples:
- - https://rust-lang.github.io/api-guidelines
- - https://deterministic.space/elegant-apis-in-rust.html
- - https://rust-unofficial.github.io/patterns
+- <https://rust-lang.github.io/api-guidelines>
+- <https://deterministic.space/elegant-apis-in-rust.html>
+- <https://rust-unofficial.github.io/patterns>
 
 ## Table of Contents
 
-1.  [Rustfmt](rustfmt.md)
-2.  [Clippy](clippy.md)
-3.  [Comments](comments.md)
-4.  [Imports](imports.md)
-5.  [Ordering](ordering.md)
-6.  [Naming](naming.md)
-7.  [Error Handling](error_handling.md)
-8.  [Macros](macros.md)
-9.  [Tests](tests.md)
+1. [Rustfmt](rustfmt.md)
+2. [Clippy](clippy.md)
+3. [Comments](comments.md)
+4. [Imports](imports.md)
+5. [Ordering](ordering.md)
+6. [Naming](naming.md)
+7. [Error Handling](error_handling.md)
+8. [Macros](macros.md)
+9. [Tests](tests.md)
 10. [Enums](enums.md)
 11. [Structs](structs.md)
 12. [Control Flow](control_flow.md)
-12. [Functions](functions.md)
-13. [Visibility](visibility.md)
+13. [Functions](functions.md)
+14. [Visibility](visibility.md)
 
 ## Contributing
 
 If you wish to contribute a new rule, please use the `SKELETON.md` as a
 structural guideline.
+
+## License
+
+MIT - with complete text available in the [LICENSE][license] file.
+
+[license]: https://github.com/phylum-dev/rust-style-guidelines/blob/master/LICENSE


### PR DESCRIPTION
Closes #2

(NOTE: the additional formatting in `README.md` happened automatically, by the "Markdown All in One" extension for VS Code, when I saved the file)